### PR TITLE
Expose the adapters

### DIFF
--- a/src/main/java/io/vavr/gson/VavrGson.java
+++ b/src/main/java/io/vavr/gson/VavrGson.java
@@ -6,6 +6,10 @@
  */
 package io.vavr.gson;
 
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Objects;
+
 import com.google.gson.GsonBuilder;
 import io.vavr.*;
 import io.vavr.collection.*;
@@ -24,7 +28,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerAll(GsonBuilder builder)  {
-        checkBuilder(builder);
+        registerAdapters(builder);
         registerTuples(builder);
         registerAllCollections(builder);
         registerAllMaps(builder);
@@ -40,7 +44,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerLazy(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Lazy.class, new LazyConverter());
+        return registerAdapters(builder, Lazy.class);
     }
 
     /**
@@ -49,7 +53,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerOption(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeHierarchyAdapter(Option.class, new OptionConverter());
+        return registerAdapters(builder).registerTypeHierarchyAdapter(Option.class, new OptionConverter());
     }
 
     /**
@@ -58,7 +62,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerAllMultimaps(GsonBuilder builder) {
-        checkBuilder(builder);
+        registerAdapters(builder);
         registerMultimap(builder);
         registerSortedMultimap(builder);
         registerHashMultimap(builder);
@@ -73,7 +77,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerHashMultimap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(HashMultimap.class, new MultimapConverter<>(t -> HashMultimap.withSeq().ofEntries(t)));
+        return registerAdapters(builder, HashMultimap.class);
     }
 
     /**
@@ -82,7 +86,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerMultimap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Multimap.class, new MultimapConverter<>(t -> HashMultimap.withSeq().ofEntries(t)));
+        return registerAdapters(builder, Multimap.class);
     }
 
     /**
@@ -91,7 +95,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerSortedMultimap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(SortedMultimap.class, new MultimapConverter<>(t -> TreeMultimap.withSeq().ofEntries(t)));
+        return registerAdapters(builder, SortedMultimap.class);
     }
 
     /**
@@ -100,7 +104,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerLinkedHashMultimap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(LinkedHashMultimap.class, new MultimapConverter<>(t -> LinkedHashMultimap.withSeq().ofEntries(t)));
+        return registerAdapters(builder, LinkedHashMultimap.class);
     }
 
     /**
@@ -109,7 +113,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerTreeMultimap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(TreeMultimap.class, new MultimapConverter<>(t -> TreeMultimap.withSeq().ofEntries(t)));
+        return registerAdapters(builder, TreeMultimap.class);
     }
 
     /**
@@ -118,7 +122,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerAllMaps(GsonBuilder builder) {
-        checkBuilder(builder);
+        registerAdapters(builder);
         registerMap(builder);
         registerSortedMap(builder);
         registerHashMap(builder);
@@ -133,7 +137,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerHashMap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(HashMap.class, new MapConverter<>(HashMap::ofEntries));
+        return registerAdapters(builder, HashMap.class);
     }
 
     /**
@@ -142,7 +146,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerMap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Map.class, new MapConverter<>(HashMap::ofEntries));
+        return registerAdapters(builder, Map.class);
     }
 
     /**
@@ -151,7 +155,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerSortedMap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(SortedMap.class, new MapConverter<>(TreeMap::ofEntries));
+        return registerAdapters(builder, SortedMap.class);
     }
 
     /**
@@ -160,7 +164,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerLinkedHashMap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(LinkedHashMap.class, new MapConverter<>(LinkedHashMap::ofEntries));
+        return registerAdapters(builder, LinkedHashMap.class);
     }
 
     /**
@@ -169,7 +173,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerTreeMap(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(TreeMap.class, new MapConverter<>(TreeMap::ofEntries));
+        return registerAdapters(builder, TreeMap.class);
     }
 
     /**
@@ -178,16 +182,16 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerTuples(GsonBuilder builder) {
-        return checkBuilder(builder)
-                .registerTypeAdapter(Tuple0.class, new TupleConverter.N0())
-                .registerTypeAdapter(Tuple1.class, new TupleConverter.N1())
-                .registerTypeAdapter(Tuple2.class, new TupleConverter.N2())
-                .registerTypeAdapter(Tuple3.class, new TupleConverter.N3())
-                .registerTypeAdapter(Tuple4.class, new TupleConverter.N4())
-                .registerTypeAdapter(Tuple5.class, new TupleConverter.N5())
-                .registerTypeAdapter(Tuple6.class, new TupleConverter.N6())
-                .registerTypeAdapter(Tuple7.class, new TupleConverter.N7())
-                .registerTypeAdapter(Tuple8.class, new TupleConverter.N8());
+        return registerAdapters(builder,
+                Tuple0.class,
+                Tuple1.class,
+                Tuple2.class,
+                Tuple3.class,
+                Tuple4.class,
+                Tuple5.class,
+                Tuple6.class,
+                Tuple7.class,
+                Tuple8.class);
     }
 
     /**
@@ -196,7 +200,6 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerAllCollections(GsonBuilder builder)  {
-        checkBuilder(builder);
         registerArray(builder);
         registerSeq(builder);
         registerIndexedSeq(builder);
@@ -221,7 +224,7 @@ public class VavrGson {
      */
     @SuppressWarnings("unchecked")
     public static GsonBuilder registerPriorityQueue(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(PriorityQueue.class, new TraversableConverter<>(it -> PriorityQueue.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)));
+        return registerAdapters(builder, PriorityQueue.class);
     }
 
     /**
@@ -230,7 +233,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerHashSet(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(HashSet.class, new TraversableConverter<>(HashSet::ofAll));
+        return registerAdapters(builder, HashSet.class);
     }
 
     /**
@@ -239,7 +242,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerSet(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Set.class, new TraversableConverter<>(HashSet::ofAll));
+        return registerAdapters(builder, Set.class);
     }
 
     /**
@@ -249,7 +252,7 @@ public class VavrGson {
      */
     @SuppressWarnings("unchecked")
     public static GsonBuilder registerSortedSet(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(SortedSet.class, new TraversableConverter<>(it -> TreeSet.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)));
+        return registerAdapters(builder, SortedSet.class);
     }
 
     /**
@@ -258,7 +261,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerLinkedHashSet(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(LinkedHashSet.class, new TraversableConverter<>(LinkedHashSet::ofAll));
+        return registerAdapters(builder, LinkedHashSet.class);
     }
 
     /**
@@ -268,7 +271,7 @@ public class VavrGson {
      */
     @SuppressWarnings("unchecked")
     public static GsonBuilder registerTreeSet(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(TreeSet.class, new TraversableConverter<>(it -> TreeSet.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)));
+        return registerAdapters(builder, TreeSet.class);
     }
 
     /**
@@ -277,7 +280,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerArray(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Array.class, new TraversableConverter<>(Array::ofAll));
+        return registerAdapters(builder, Array.class);
     }
 
     /**
@@ -286,7 +289,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerSeq(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Seq.class, new TraversableConverter<>(List::ofAll));
+        return registerAdapters(builder, Seq.class);
     }
 
     /**
@@ -295,7 +298,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerIndexedSeq(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(IndexedSeq.class, new TraversableConverter<>(Vector::ofAll));
+        return registerAdapters(builder, IndexedSeq.class);
     }
 
     /**
@@ -304,7 +307,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerLinearSeq(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(LinearSeq.class, new TraversableConverter<>(List::ofAll));
+        return registerAdapters(builder, LinearSeq.class);
     }
 
     /**
@@ -313,7 +316,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerList(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeHierarchyAdapter(List.class, new TraversableConverter<>(List::ofAll));
+        return registerAdapters(builder, List.class);
     }
 
     /**
@@ -322,7 +325,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerQueue(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Queue.class, new TraversableConverter<>(Queue::ofAll));
+        return registerAdapters(builder, Queue.class);
     }
 
     /**
@@ -331,7 +334,7 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerStream(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeHierarchyAdapter(Stream.class, new TraversableConverter<>(Stream::ofAll));
+        return registerAdapters(builder, Stream.class);
     }
 
     /**
@@ -340,13 +343,82 @@ public class VavrGson {
      * @return A reference to {@code builder}.
      */
     public static GsonBuilder registerVector(GsonBuilder builder) {
-        return checkBuilder(builder).registerTypeAdapter(Vector.class, new TraversableConverter<>(Vector::ofAll));
+        return registerAdapters(builder, Vector.class);
     }
 
-    private static GsonBuilder checkBuilder(GsonBuilder builder) {
-        if (builder == null) {
-            throw new NullPointerException("builder cannot be null");
-        }
+    public static Map<Type, Object> typeAdapters() {
+        return collectionTypeAdapters()
+                .merge(tupleTypeAdapters())
+                .merge(mapTypeAdapters())
+                .merge(multiMapTypeAdapters())
+                .merge(lazyTypeAdapters());
+    }
+
+    public static Map<Class<?>, Object> typeHierarchyAdapters() {
+        return API.<Class<?>, Object>Map()
+                .put(List.class, new TraversableConverter<>(List::ofAll))
+                .put(Stream.class, new TraversableConverter<>(Stream::ofAll))
+                .put(Option.class, new OptionConverter());
+    }
+
+    public static Map<Type, Object> lazyTypeAdapters() {
+        return API.<Type, Object>Map()
+                .put(Lazy.class, new LazyConverter());
+    }
+
+    public static Map<Type, Object> multiMapTypeAdapters() {
+        return API.<Type, Object>Map()
+                .put(Multimap.class, new MultimapConverter<>(t -> HashMultimap.withSeq().ofEntries(t)))
+                .put(SortedMultimap.class, new MultimapConverter<>(t -> TreeMultimap.withSeq().ofEntries(t)))
+                .put(HashMultimap.class, new MultimapConverter<>(t -> HashMultimap.withSeq().ofEntries(t)))
+                .put(LinkedHashMultimap.class, new MultimapConverter<>(t -> LinkedHashMultimap.withSeq().ofEntries(t)))
+                .put(TreeMultimap.class, new MultimapConverter<>(t -> TreeMultimap.withSeq().ofEntries(t)));
+    }
+
+    public static Map<Type, Object> mapTypeAdapters() {
+        return API.<Type, Object>Map()
+                .put(Map.class, new MapConverter<>(HashMap::ofEntries))
+                .put(SortedMap.class, new MapConverter<>(TreeMap::ofEntries))
+                .put(HashMap.class, new MapConverter<>(HashMap::ofEntries))
+                .put(LinkedHashMap.class, new MapConverter<>(LinkedHashMap::ofEntries))
+                .put(TreeMap.class, new MapConverter<>(TreeMap::ofEntries));
+    }
+
+    public static Map<Type, Object> collectionTypeAdapters() {
+        return API.<Type, Object>Map()
+                .put(Array.class, new TraversableConverter<>(Array::ofAll))
+                .put(Seq.class, new TraversableConverter<>(List::ofAll))
+                .put(IndexedSeq.class, new TraversableConverter<>(Vector::ofAll))
+                .put(LinearSeq.class, new TraversableConverter<>(List::ofAll))
+                .put(Queue.class, new TraversableConverter<>(Queue::ofAll))
+                .put(Vector.class, new TraversableConverter<>(Vector::ofAll))
+                .put(Set.class, new TraversableConverter<>(HashSet::ofAll))
+                .put(SortedSet.class, new TraversableConverter<>(it -> TreeSet.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)))
+                .put(HashSet.class, new TraversableConverter<>(HashSet::ofAll))
+                .put(LinkedHashSet.class, new TraversableConverter<>(LinkedHashSet::ofAll))
+                .put(TreeSet.class, new TraversableConverter<>(it -> TreeSet.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)))
+                .put(PriorityQueue.class, new TraversableConverter<>(it -> PriorityQueue.ofAll((o1, o2) -> ((Comparable) o1).compareTo(o2), it)));
+    }
+
+    public static Map<Type, Object> tupleTypeAdapters() {
+        return API.Map(Tuple0.class, new TupleConverter.N0(),
+                Tuple1.class, new TupleConverter.N1(),
+                Tuple2.class, new TupleConverter.N2(),
+                Tuple3.class, new TupleConverter.N3(),
+                Tuple4.class, new TupleConverter.N4(),
+                Tuple5.class, new TupleConverter.N5(),
+                Tuple6.class, new TupleConverter.N6(),
+                Tuple7.class, new TupleConverter.N7(),
+                Tuple8.class, new TupleConverter.N8());
+    }
+
+    private static GsonBuilder registerAdapters(GsonBuilder builder, Class<?> ...types) {
+        Objects.requireNonNull(builder, "builder cannot be null");
+        List.ofAll(Arrays.asList(types))
+                .forEach(type -> {
+                    typeAdapters().get(type).map(adapter -> builder.registerTypeAdapter(type, adapter));
+                    typeHierarchyAdapters().get(type).map(adapter -> builder.registerTypeHierarchyAdapter(type, adapter));
+                });
         return builder;
     }
 }


### PR DESCRIPTION
**Rationale:** I use a library that serializes objects to Json using Gson without exposing a GsonBuilder to me for configuration (https://github.com/karsaig/approvalcrest). Instead, it accepts a configuration object. 

I wish to use vavr types with this library, so I must provide type adapters. The type adapters are not exported from this library, so I can't use them as-is.

This PR addresses the issue by exposing 2 maps `typeAdapters()` and `typeHierarchyAdapters()` for general access to type adapters in this module without requiring a GsonBuilder. Internally, these maps are also used for registering type adapters with a GsonBuilder, in order to avoid code duplication. 